### PR TITLE
BugFix: Setting backgroundImage instead of background

### DIFF
--- a/ng2-parallax-directive/parallax.directive.ts
+++ b/ng2-parallax-directive/parallax.directive.ts
@@ -34,7 +34,7 @@ export class ng2parallax implements OnInit {
         bgObj.style.height = "100%";
         bgObj.style.margin = "0 auto"
         bgObj.style.position = "relative"
-        bgObj.style.background = "url(" + _img + ")"
+        bgObj.style.backgroundImage = "url(" + _img + ")"
         bgObj.style.backgroundAttachment = 'fixed';
     var isMobile = window.mobileAndTabletcheck();
 


### PR DESCRIPTION
Setting backgroundImage instead of background

This way the generated inline style won't overwrite every background-* css properties.
So it is possible this way to add eg a custom background-color to be shown while a possibly big image gets downloaded via a possibly slow network